### PR TITLE
added a way to start/stop paperspace instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Intellij
+.idea/
+
 # Distribution / packaging
 .Python
 env/

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -18,7 +18,7 @@ RUN pip3 --no-cache-dir install --upgrade setuptools numpy scipy
 RUN pip3 --no-cache-dir install --upgrade \
         sklearn matplotlib pandas pygments \
         tensorflow \
-        keras h5py pydot docker Flask Flask-API Flask-HTTPAuth boto3 awscli
+        keras h5py pydot docker Flask Flask-API Flask-HTTPAuth boto3 awscli requests
 
 # install our package
 ADD . /home/root/insight

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -18,7 +18,7 @@ RUN pip3 --no-cache-dir install --upgrade setuptools numpy scipy
 RUN pip3 --no-cache-dir install --upgrade \
         sklearn matplotlib pandas pygments \
         tensorflow-gpu \
-        keras h5py pydot docker Flask Flask-API Flask-HTTPAuth boto3 awscli
+        keras h5py pydot docker Flask Flask-API Flask-HTTPAuth boto3 awscli requests
 
 # AWS credential env
 ENV AWS_ACCESS_KEY_ID ""

--- a/package/insight/paperspace.py
+++ b/package/insight/paperspace.py
@@ -1,0 +1,33 @@
+import os
+import requests
+
+PAPERSPACE_API_KEY = ''
+CONFIG_HOST = 'https://api.paperspace.io'
+
+if 'PAPERSPACE_API_KEY' in os.environ:
+    PAPERSPACE_API_KEY = os.environ['PAPERSPACE_API_KEY']
+
+
+class Paperspace():
+
+    @staticmethod
+    def start_machine(machine_id):
+        http_method = 'POST'
+        path = '/machines/' + machine_id + '/start'
+        r = requests.request(http_method, CONFIG_HOST + path, headers={'x-api-key': PAPERSPACE_API_KEY})
+
+        if r.status_code == 204:
+            return {}
+        else:
+            return r.json()
+
+    @staticmethod
+    def stop_machine(machine_id):
+        http_method = 'POST'
+        path = '/machines/' + machine_id + '/stop'
+        r = requests.request(http_method, CONFIG_HOST + path, headers={'x-api-key': PAPERSPACE_API_KEY})
+
+        if r.status_code == 204:
+            return {}
+        else:
+            return r.json()

--- a/package/insight/web/REST_server.py
+++ b/package/insight/web/REST_server.py
@@ -9,10 +9,14 @@ from flask_api import FlaskAPI
 from flask_httpauth import HTTPBasicAuth
 from insight.storage import AWSResource, DBInstanceLog
 from insight.builder import Convert
+from insight.paperspace import Paperspace
 
 
 # global AWS resource
 aws = AWSResource()
+
+# global Paperspace resource
+paperspace = Paperspace()
 
 # flask application
 app = FlaskAPI(__name__, static_folder='static')
@@ -332,8 +336,10 @@ def delete_weights_file(weights_file):
 
 
 '''
-GET	    /insight/api/v1.0/workers             Retrieve list of active instances
-POST    /insight/api/v1.0/workers/report      report a worker's status
+GET	    /insight/api/v1.0/workers                       Retrieve list of active instances
+POST    /insight/api/v1.0/workers/report                report a worker's status
+POST    /insight/api/v1.0/workers/paperspace_start      start paperspace worker
+POST    /insight/api/v1.0/workers/paperspace_stop       stop paperspace worker
 '''
 
 
@@ -378,6 +384,26 @@ def report_worker():
     }
     aws.workers.report(internal_json['name'], system_info, internal_json['status'])
     return {"result": True}
+
+
+@app.route('/insight/api/v1.0/workers/paperspace_start', methods=["POST"])
+def start_paperspace_worker():
+    if not request.json or 'machineId' not in request.json:
+        abort(400, 'missing parameter: machineId')
+
+    machine_id = request.json['machineId']
+    response = Paperspace.start_machine(machine_id)
+    return response
+
+
+@app.route('/insight/api/v1.0/workers/paperspace_stop', methods=["POST"])
+def stop_paperspace_worker():
+    if not request.json or 'machineId' not in request.json:
+        abort(400, 'missing parameter: machineId')
+
+    machine_id = request.json['machineId']
+    response = Paperspace.stop_machine(machine_id)
+    return response
 
 
 '''

--- a/package/insight/web/static/index.html
+++ b/package/insight/web/static/index.html
@@ -145,9 +145,10 @@
                             <thead>
                                 <tr>
                                     <th width=40%>Name</th>
-                                    <th width=20%>Status</th>
-                                    <th width=20%>Last seen</th>
-                                    <th width=20%>Server Info</th>
+                                    <th width=15%>Status</th>
+                                    <th width=15%>Last seen</th>
+                                    <th width=15%>Server Info</th>
+                                    <th width=15%>Action</th>
                                 </tr>
                             </thead>
                             <tbody id="cluster-table-body">
@@ -234,10 +235,13 @@
         <td>
             <%= system_info %>
         </td>
+        <td>
+            <button type="button" class="btn btn-outline-primary <%= current_status == 'offline' ? 'start-worker' : 'stop-worker'%> <%= remotely_controlled ? '' : 'disabled' %>"><%= current_status == 'offline' ? 'Start' : 'Stop'%></button>
+        </td>
     </script>
 
     <!-- Add JSON Modal -->
-    <div id="add-json-model" class="modal fade" rold="dialog">
+    <div id="add-json-model" class="modal fade" role="dialog">
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header login-header">

--- a/package/insight/web/static/js/models/worker.js
+++ b/package/insight/web/static/js/models/worker.js
@@ -10,7 +10,63 @@ var app = app || {};
             last_seen: '',
             system_info: '',
             idle: '',
-            status_color: ''
+            status_color: '',
+            remotely_controlled: false
         },
+
+        _startWorker: function() {
+            var model = this;
+            var workerName = this.get("worker_name");
+
+            if(workerName === undefined || !workerName.includes("_paperspace")) {
+                return false;
+            } else {
+                var machineId = workerName.split('-')[1];
+                if(machineId !== undefined) {
+                    Backbone.ajax(_.extend({
+                        url: "/insight/api/v1.0/workers/paperspace_start",
+                        method: "POST",
+                        data: JSON.stringify({"machineId": machineId}),
+                        contentType: "application/json",
+                        success: function() {
+                            model.set("current_status", "running");
+                        },
+                        error: function(response) {
+                            console.log(response);
+                        }
+
+                    }));
+                }
+
+            }
+        },
+
+        _stopWorker: function() {
+            var model = this;
+            var workerName = this.get("worker_name");
+
+            if(workerName === undefined || !workerName.includes("_paperspace")) {
+                return false;
+            } else {
+                var machineId = workerName.split('-')[1];
+                if(machineId !== undefined) {
+                    Backbone.ajax(_.extend({
+                        url: "/insight/api/v1.0/workers/paperspace_stop",
+                        method: "POST",
+                        data: JSON.stringify({"machineId": machineId}),
+                        contentType: "application/json",
+                        success: function() {
+                            model.set("current_status", "offline");
+                        },
+                        error: function(response) {
+                            console.log(response);
+                        }
+
+                    }));
+                }
+
+            }
+        }
+
     });
 })();

--- a/package/insight/web/static/js/views/worker-view.js
+++ b/package/insight/web/static/js/views/worker-view.js
@@ -2,24 +2,46 @@ var app = app || {};
 
 app.WorkerView = Backbone.View.extend({
     tagName: 'tr',
+
+    events: {
+        'click .start-worker': '_startWorker',
+        'click .stop-worker': '_stopWorker'
+    },
+
     template: _.template($('#worker-template').html()),
 
     initialize: function() {
         this.render();
+        this.listenTo(this.model, "change", this.render);
     },
 
     render: function() {
         var status_val = this.model.get("current_status");
         var status = "";
-        if (status_val == "training") {
+        if (status_val === "training") {
             status = "badge badge-pill badge-warning";
-        } else if (status_val == "idle") {
+        } else if (status_val === "idle") {
             status = "badge badge-pill badge-success";
-        } else if (status_val == "offline") {
+        } else if (status_val === "offline") {
             status = "badge badge-pill badge-secondary";
         }
         this.model.set("status_color", status);
+        this.model.set("remotely_controlled", this._isRemotelyControlled(this.model.get("worker_name")));
         this.$el.html(this.template(this.model.attributes));
         return this
     },
+
+    _isRemotelyControlled: function(workerName) {
+        return workerName.includes("_paperspace");
+    },
+
+    _startWorker: function(e) {
+        e.preventDefault();
+        this.model._startWorker();
+    },
+
+    _stopWorker: function(e) {
+        e.preventDefault();
+        this.model._stopWorker();
+    }
 });

--- a/start_restful_docker_service.sh
+++ b/start_restful_docker_service.sh
@@ -10,4 +10,10 @@ setting_file=/home/root/insight/package/insight/applications/settings.py
 # external port
 ext_port=80
 
-docker run --rm -d --name insight-restful -v ${aws_config}:/root/.aws -v ${PWD}/settings.py:${setting_file} -p ${ext_port}:9000 insight/kservice
+docker run --rm -d --name insight-restful \
+    -v ${aws_config}:/root/.aws \
+    -v ${PWD}/settings.py:${setting_file} \
+    -p ${ext_port}:9000 \
+    -e FLASK_DEBUG=1 \
+    -e PAPERSPACE_API_KEY=$PAPERSPACE_API_KEY \
+    insight/kservice


### PR DESCRIPTION
Overview:
1) Modified worker.js view and model to have an extra 'actions' column that contains button to start/stop a worker. The buttons will only be active if worker's name contains '_paperspace' keyword

2) Added two routes to `RESTservice.py` to start/stop paperspace instances

3) Added `Paperspace` class as a wrapper for paperspace api. Currently, the class only implements to methods to start/stop instances

That's pretty much it - this hack is using a convention where paperspace's machine_id is prepended with '_paperspace-' and that's how `Worker` backbone model knows which machine to turn on/off (worker.js:51)


Let me know if I forgot to include something, thanks!